### PR TITLE
Add mechanism for specifying custom Date parsers

### DIFF
--- a/src/main/java/org/mcsoxford/rss/DateParser.java
+++ b/src/main/java/org/mcsoxford/rss/DateParser.java
@@ -1,0 +1,5 @@
+package org.mcsoxford.rss;
+
+public interface DateParser {
+    java.util.Date parse(String date);
+}

--- a/src/main/java/org/mcsoxford/rss/DateParser.java
+++ b/src/main/java/org/mcsoxford/rss/DateParser.java
@@ -1,5 +1,14 @@
 package org.mcsoxford.rss;
 
+/**
+ * Generic interface for parsing RSS dates
+ */
 public interface DateParser {
+    /**
+     * Turn the given string date into a Date object
+     *
+     * @param date the raw date found in the RSS feed
+     * @return parsed Date, or null if unsuccessful
+     */
     java.util.Date parse(String date);
 }

--- a/src/main/java/org/mcsoxford/rss/RSSConfig.java
+++ b/src/main/java/org/mcsoxford/rss/RSSConfig.java
@@ -41,6 +41,10 @@ public final class RSSConfig {
    */
   final byte thumbnailAvg;
 
+  /**
+   * List of DataParser implementations which will be queried in-order to deserialize
+   * date strings.
+   */
   final List<DateParser> dateParsers;
 
   /**
@@ -50,6 +54,7 @@ public final class RSSConfig {
    *          a typical RSS feed
    * @param thumbnailAvg average number of RSS item &lt;metia:thumbnail&gt;
    *          elements in a typical RSS feed
+   * @param dateParsers DateParser implementations for parsing dates found in RSS feed
    */
   public RSSConfig(byte categoryAvg, byte thumbnailAvg, List<DateParser> dateParsers) {
     this.categoryAvg = categoryAvg;

--- a/src/main/java/org/mcsoxford/rss/RSSConfig.java
+++ b/src/main/java/org/mcsoxford/rss/RSSConfig.java
@@ -16,11 +16,15 @@
 
 package org.mcsoxford.rss;
 
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
 /**
  * Immutable data structure to configure the RSS parser and loader modules. On
  * large data sets, well-chosen configuration values can reduce memory
  * consumption and increase performance.
- * 
+ *
  * @author Mr Horn
  */
 public final class RSSConfig {
@@ -37,17 +41,20 @@ public final class RSSConfig {
    */
   final byte thumbnailAvg;
 
+  final List<DateParser> dateParsers;
+
   /**
    * Instantiate an RSS configuration with the specified parameters.
-   * 
+   *
    * @param categoryAvg average number of RSS item &lt;category&gt; elements in
    *          a typical RSS feed
    * @param thumbnailAvg average number of RSS item &lt;metia:thumbnail&gt;
    *          elements in a typical RSS feed
    */
-  public RSSConfig(byte categoryAvg, byte thumbnailAvg) {
+  public RSSConfig(byte categoryAvg, byte thumbnailAvg, List<DateParser> dateParsers) {
     this.categoryAvg = categoryAvg;
     this.thumbnailAvg = thumbnailAvg;
+    this.dateParsers = Collections.unmodifiableList(new ArrayList<DateParser>(dateParsers));
   }
 
   /**
@@ -56,6 +63,7 @@ public final class RSSConfig {
   public RSSConfig() {
     this.categoryAvg = 3;
     this.thumbnailAvg = 2;
+    this.dateParsers = Collections.unmodifiableList(Collections.<DateParser>singletonList(new Rfc822DateParser()));
   }
 
 }

--- a/src/main/java/org/mcsoxford/rss/RSSHandler.java
+++ b/src/main/java/org/mcsoxford/rss/RSSHandler.java
@@ -16,6 +16,8 @@
 
 package org.mcsoxford.rss;
 
+import java.util.Date;
+
 /**
  * Internal SAX handler to efficiently parse RSS feeds. Only a single thread
  * must use this SAX handler.
@@ -160,7 +162,7 @@ class RSSHandler extends org.xml.sax.helpers.DefaultHandler {
   private final Setter SET_PUBDATE = new ContentSetter() {
     @Override
     public void set(String pubDate) {
-      final java.util.Date date = Dates.parseRfc822(pubDate);
+      final java.util.Date date = parseDate(pubDate);
       if (item == null) {
         feed.setPubDate(date);
       } else {
@@ -175,7 +177,7 @@ class RSSHandler extends org.xml.sax.helpers.DefaultHandler {
 	private final Setter SET_LAST_BUILE_DATE = new ContentSetter() {
 		@Override
 		public void set(String pubDate) {
-			final java.util.Date date = Dates.parseRfc822(pubDate);
+			final java.util.Date date = parseDate(pubDate);
 			if (item == null) {
 				feed.setLastBuildDate(date);
 			} else {
@@ -282,6 +284,16 @@ class RSSHandler extends org.xml.sax.helpers.DefaultHandler {
 			item.setEnclosure(enclosure);
 		}
 	};
+
+	private Date parseDate(String date) {
+	    for (DateParser parser : config.dateParsers) {
+	        Date result = parser.parse(date);
+	        if (result != null) {
+	            return result;
+            }
+        }
+        throw new RSSFault("No parsers able to handle date " + date);
+    }
 
   /**
    * Use configuration to optimize initial capacities of collections

--- a/src/main/java/org/mcsoxford/rss/Rfc822DateParser.java
+++ b/src/main/java/org/mcsoxford/rss/Rfc822DateParser.java
@@ -21,7 +21,7 @@ import java.text.SimpleDateFormat;
 import java.util.Date;
 
 /**
- * Internal helper class for date conversions.
+ * Canonical DateParser implementation for RSS spec. Checks against RFC-822.
  * 
  * @author Mr Horn
  */

--- a/src/main/java/org/mcsoxford/rss/Rfc822DateParser.java
+++ b/src/main/java/org/mcsoxford/rss/Rfc822DateParser.java
@@ -18,13 +18,14 @@ package org.mcsoxford.rss;
 
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
+import java.util.Date;
 
 /**
  * Internal helper class for date conversions.
  * 
  * @author Mr Horn
  */
-final class Dates {
+final class Rfc822DateParser implements DateParser {
 
   /**
    * @see <a href="http://www.ietf.org/rfc/rfc0822.txt">RFC 822</a>
@@ -32,21 +33,22 @@ final class Dates {
   private static final SimpleDateFormat RFC822 = new SimpleDateFormat(
       "EEE, dd MMM yyyy HH:mm:ss Z", java.util.Locale.ENGLISH);
 
-  /* Hide constructor */
-  private Dates() {}
+  public Rfc822DateParser() {}
   
   /**
    * Parses string as an RFC 822 date/time.
-   * 
-   * @throws RSSFault if the string is not a valid RFC 822 date/time
    */
   static java.util.Date parseRfc822(String date) {
     try {
       return RFC822.parse(date);
     } catch (ParseException e) {
-      throw new RSSFault(e);
+      return null;
     }
   }
 
+  @Override
+  public Date parse(String date) {
+    return parseRfc822(date);
+  }
 }
 


### PR DESCRIPTION
Hey thanks for the library, it works great.

I was dealing with some 'malformed' RSS in that it didn't adhere to the RSS spec for dates, so I needed to customize how Date objects are handled. It might be useful for others dealing with real-world feeds as well.